### PR TITLE
remove last added note with backspace

### DIFF
--- a/src/game_board.py
+++ b/src/game_board.py
@@ -68,7 +68,7 @@ class GameBoard:
         self.notes = (
             notes
             if notes
-            else [[set() for _ in range(GRID_SIZE)] for _ in range(GRID_SIZE)]
+            else [[list() for _ in range(GRID_SIZE)] for _ in range(GRID_SIZE)]
         )
 
     def to_dict(self):
@@ -94,10 +94,10 @@ class GameBoard:
         return self.notes[row][col]
 
     def add_note(self, row: int, col: int, value: str):
-        self.notes[row][col].add(value)
+        self.notes[row][col].append(value)
 
     def remove_note(self, row: int, col: int, value: str):
-        self.notes[row][col].discard(value)
+        self.notes[row][col].remove(value)
 
     def clear_notes(self, row: int, col: int):
         self.notes[row][col].clear()
@@ -128,7 +128,7 @@ class GameBoard:
             with open(SAVE_PATH, "r") as f:
                 data = json.load(f)
 
-            notes = [[set(cell) for cell in row] for row in data["notes"]]
+            notes = [[list(cell) for cell in row] for row in data["notes"]]
             difficulty_label = data.get("difficulty_label", "Unknown")
             return cls(
                 difficulty=data["difficulty"],

--- a/src/game_manager.py
+++ b/src/game_manager.py
@@ -159,8 +159,9 @@ class GameManager:
     def _clear_cell(self, cell: SudokuCell):
         row, col = cell.row, cell.col
         if self.pencil_mode:
-            self.game_board.clear_notes(row, col)
-            cell.update_notes(set())
+            if len(self.game_board.get_notes(row, col)) > 0:
+                self.game_board.get_notes(row, col).pop()
+                cell.update_notes(self.game_board.get_notes(row, col))
         else:
             cell.set_value("")
             cell.set_tooltip_text("")


### PR DESCRIPTION
fix issue #20 

hi @sepehr-rs 
I completed the problem and now in Sudoku, only the last note will be deleted by deleting or pressing backspace. 

I also changed all set() to list so that the order is well preserved. 
