### PR TITLE
more transparent numbers

### DIFF
--- a/src/style.css
+++ b/src/style.css
@@ -30,7 +30,13 @@ statuspage image {
     background-color: #f1e2c8;
 }
 
-.entry-cell, .clue-cell {
+.entry-cell {
+    color: rgba(34, 26, 21,1);
+    font-size: 20px;
+}
+
+.clue-cell {
+    color: rgba(34, 26, 21, 0.70);
     font-size: 20px;
 }
 


### PR DESCRIPTION
#18 
Default numbers are more transparent than those that are entered by the user.

<img width="802" height="700" alt="sc" src="https://github.com/user-attachments/assets/fdfd7f5f-ed4e-4230-a2e1-772b931b14d4" />
