### PR TITLE
Enhancement: Add Delete key to remove all notes in a cell

### DIFF
--- a/src/game_manager.py
+++ b/src/game_manager.py
@@ -34,7 +34,8 @@ class GameManager:
         self.conflict_cells = []
         self.pencil_mode = False
 
-        self.key_map, self.remove_cell_keybindings = UIHelpers.setup_key_mappings()
+        keys = UIHelpers.setup_key_mappings()
+        self.key_map, self.remove_cell_keybindings, self.remove_note_keybindings = keys
 
         self._setup_actions()
 
@@ -156,9 +157,9 @@ class GameManager:
         self.cell_inputs[row][col].grab_focus()
         UIHelpers.highlight_related_cells(self.cell_inputs, row, col)
 
-    def _clear_cell(self, cell: SudokuCell):
+    def _clear_cell(self, cell: SudokuCell, clear_notes: bool=False):
         row, col = cell.row, cell.col
-        if self.pencil_mode:
+        if self.pencil_mode or clear_notes:
             self.game_board.clear_notes(row, col)
             cell.update_notes(set())
         else:
@@ -267,6 +268,9 @@ class GameManager:
 
         if keyval in self.remove_cell_keybindings and cell.editable:
             self._clear_cell(cell)
+            return True
+        elif keyval in self.remove_note_keybindings:
+            self._clear_cell(cell, clear_notes=True)
             return True
 
         return False

--- a/src/ui_helpers.py
+++ b/src/ui_helpers.py
@@ -43,11 +43,15 @@ class UIHelpers:
 
         remove_cell_keybindings = (
             Gdk.KEY_BackSpace,
+        )
+
+        remove_note_keybindings = (
             Gdk.KEY_Delete,
             Gdk.KEY_KP_Delete,
         )
 
-        return key_map, remove_cell_keybindings
+        return key_map, remove_cell_keybindings, \
+                remove_note_keybindings
 
     @staticmethod
     def clear_highlights(cells: list, class_name: str):


### PR DESCRIPTION
#123 
Now the Delete key and Delete keypad key can remove notes in both normal mode and pencil mode.
It can also be like this without the extra "clear_note" parameter.

```python
# src/game_manager.py: line 272
elif keyval in self.remove_note_keybindings:
    self.pencil_mode = True
    self._clear_cell(cell)
    self.pencil_mode = False
    return True
```