### PR TITLE
Note on right click

### DIFF
--- a/src/game_manager.py
+++ b/src/game_manager.py
@@ -120,6 +120,7 @@ class GameManager:
 
                 # Gesture click controller
                 gesture = Gtk.GestureClick.new()
+                gesture.set_button(0)
                 gesture.connect("pressed", self.on_cell_clicked, cell)
                 cell.add_controller(gesture)
 
@@ -180,11 +181,11 @@ class GameManager:
         UIHelpers.clear_feedback_classes(cell.get_style_context())
         self.game_board.set_input(row, col, None)
 
-    def _fill_cell(self, cell: SudokuCell, number: str, ctrl_is_pressed=False):
+    def _fill_cell(self, cell: SudokuCell, number: str, write_note=False):
         UIHelpers.clear_conflicts(self.conflict_cells)
         row, col = cell.row, cell.col
 
-        if self.pencil_mode or ctrl_is_pressed:
+        if self.pencil_mode or write_note:
             if number in self.game_board.get_notes(row, col):
                 self.game_board.remove_note(row, col, number)
             else:
@@ -207,7 +208,7 @@ class GameManager:
         if self.game_board.is_solved():
             self._show_puzzle_finished_dialog()
 
-    def _show_popover(self, cell: SudokuCell):
+    def _show_popover(self, cell: SudokuCell, mouse_button):
         popover = Gtk.Popover()
         popover.set_has_arrow(False)
         popover.set_position(Gtk.PositionType.BOTTOM)
@@ -218,7 +219,7 @@ class GameManager:
         num_buttons = {}
         for i in range(1, 10):
             b = UIHelpers.create_number_button(
-                str(i), self.on_number_selected, cell, popover
+                str(i), self.on_number_selected, cell, popover, mouse_button
             )
             grid.attach(b, (i - 1) % 3, (i - 1) // 3, 1, 1)
             num_buttons[str(i)] = b
@@ -248,7 +249,7 @@ class GameManager:
     def on_cell_clicked(self, gesture, n_press, x: int, y: int, cell: SudokuCell):
         UIHelpers.highlight_related_cells(self.cell_inputs, cell.row, cell.col)
         if cell.editable and n_press == 1:
-            self._show_popover(cell)
+            self._show_popover(cell, gesture.get_current_button())
         else:
             cell.grab_focus()
 
@@ -292,9 +293,14 @@ class GameManager:
 
         return False
 
-    def on_number_selected(self, num_button: Gtk.Button, cell: SudokuCell, popover):
+    def on_number_selected(
+            self, num_button: Gtk.Button, cell: SudokuCell, popover, mouse_button
+    ):
         number = num_button.get_label()
-        self._fill_cell(cell, number)
+        if mouse_button == 1:
+            self._fill_cell(cell, number)
+        elif mouse_button == 3:
+            self._fill_cell(cell, number, True)
         popover.popdown()
 
     def on_clear_selected(self, clear_button, cell: SudokuCell, popover):
@@ -332,3 +338,4 @@ class GameManager:
         self.window.sudoku_window_title.set_subtitle("")
         self.window.stack.set_visible_child(self.window.main_menu_box)
         self.window.continue_button.set_sensitive(GameBoard.has_saved_game())
+

--- a/src/game_manager.py
+++ b/src/game_manager.py
@@ -338,4 +338,3 @@ class GameManager:
         self.window.sudoku_window_title.set_subtitle("")
         self.window.stack.set_visible_child(self.window.main_menu_box)
         self.window.continue_button.set_sensitive(GameBoard.has_saved_game())
-


### PR DESCRIPTION
hi @sepehr-rs  
As you can see the number dialog with left click and add your final numbers 
Now in Sudoku you can add new notes by right clicking on the cells 

Exactly issue number #77  also mentions this feature. Of course thanks to @MirS0bhan


https://github.com/user-attachments/assets/a7e54616-757f-487d-baa2-040ecf7ac3ab

  
