### PR TITLE
solved issue201

### DIFF
--- a/data/style.css
+++ b/data/style.css
@@ -1,120 +1,145 @@
 .sudoku-main-window {
-    background-color: #d2a56d;
+  background-color: #d2a56d;
 }
 
 statuspage image {
-    -gtk-icon-size: 256px;
+  -gtk-icon-size: 256px;
 }
 
 #sudoku-parent-grid {
-    background-color: rgba(247, 233, 213, 0.22);
-    padding: 50px;
-    border-radius: 20px;
-    box-shadow: 0 4px 8px rgba(0, 0, 0, 0.1);
+  background-color: rgba(247, 233, 213, 0.22);
+  padding: 50px;
+  border-radius: 20px;
+  box-shadow: 0 4px 8px rgba(0, 0, 0, 0.1);
 }
 
 #sudoku-parent-grid button {
-    background-color: rgba(247, 233, 213, 0.45);
+  background-color: rgba(247, 233, 213, 0.45);
 }
 
 #sudoku-parent-grid button.toggle-active {
-    background-color: #f1e2c8;
-    box-shadow: 0 0 10px #d2a56d88;
+  background-color: #f1e2c8;
+  box-shadow: 0 0 10px #d2a56d88;
 }
 
 #sudoku-parent-grid button:hover {
-    background-color: rgba(247, 233, 213, 0.70);
+  background-color: rgba(247, 233, 213, 0.7);
 }
 
 #sudoku-parent-grid button:checked {
-    background-color: #f1e2c8;
+  background-color: #f1e2c8;
 }
 
 .entry-cell {
-    color: rgba(34, 26, 21,1);
-    font-size: 20px;
+  color: rgba(34, 26, 21, 1);
+  font-size: 20px;
 }
 
 .clue-cell {
-    color: rgba(34, 26, 21, 0.60);
-    font-size: 20px;
+  color: rgba(34, 26, 21, 0.6);
+  font-size: 20px;
 }
 
 .sudoku-cell-button {
-    min-width: 10px;
-    min-height: 10px;
+  min-width: 10px;
+  min-height: 10px;
 }
 
 #sudoku-parent-grid button.entry-cell.correct {
-    background-color: rgba(158, 188, 62, 0.52);
-    transition: background-color 0.3s ease-in-out;
+  background-color: rgba(158, 188, 62, 0.52);
+  transition: background-color 0.3s ease-in-out;
 }
 
 #sudoku-parent-grid button.entry-cell.wrong {
-    background-color: rgba(206, 106, 64, 0.50);
+  background-color: rgba(206, 106, 64, 0.5);
 }
 
 #sudoku-parent-grid button.entry-cell.correct.highlight {
-    background-color: rgba(180, 206, 80, 0.64);
+  background-color: rgba(180, 206, 80, 0.64);
 }
 
 #sudoku-parent-grid button.entry-cell.wrong.highlight {
-    background-color: rgba(226, 126, 86, 0.64);
+  background-color: rgba(226, 126, 86, 0.64);
 }
 
 #sudoku-parent-grid button.conflict {
-    background-color: rgba(206, 106, 64, 0.40);
-    animation: pulse 3s;
+  background-color: rgba(206, 106, 64, 0.4);
+  animation: pulse 3s;
 }
 
 #sudoku-parent-grid button.entry-cell.highlight,
 #sudoku-parent-grid button.clue-cell.highlight {
-    background-color: #f7ecd8;
-    box-shadow: 0 0 10px #d2a56d79;
-    transition: background-color 0.3s ease-in-out;
+  background-color: #f7ecd8;
+  box-shadow: 0 0 10px #d2a56d79;
+  transition: background-color 0.3s ease-in-out;
 }
 
 @keyframes pulse {
-    20% { background-color: rgba(226, 126, 86, 0.64); }
-    80% { background-color: rgba(226, 126, 86, 0.64); }
+  20% {
+    background-color: rgba(226, 126, 86, 0.64);
+  }
+  80% {
+    background-color: rgba(226, 126, 86, 0.64);
+  }
 }
 
 .note-cell-label {
-    font-size: 11px;
-    padding: 0.8px;
+  font-size: 11px;
+  padding: 0.8px;
 }
 
 .width-compact #sudoku-parent-grid {
-    padding: 10px; /* shrink board padding */
-    border-radius: 6px;
+  padding: 10px; /* shrink board padding */
+  border-radius: 6px;
 }
 
-.width-compact  .entry-cell,
-.width-compact  .clue-cell {
-    font-size: 16px;
+.width-compact .entry-cell,
+.width-compact .clue-cell {
+  font-size: 16px;
 }
 
 .width-compact .note-cell-label {
-    font-size: 5px;
-    padding: 0.01px;
+  font-size: 5px;
+  padding: 0.01px;
 }
 
 .height-compact #sudoku-parent-grid {
-    padding: 10px; /* shrink board padding */
-    border-radius: 6px;
+  padding: 10px; /* shrink board padding */
+  border-radius: 6px;
 }
 
 .height-compact .sudoku-cell-button {
-    min-width: 5px;
-    min-height: 5px;
+  min-width: 5px;
+  min-height: 5px;
 }
 
-.height-compact  .entry-cell,
+.height-compact .entry-cell,
 .height-compact .clue-cell {
-    font-size: 10px;
+  font-size: 10px;
 }
 
 .height-compact .note-cell-label {
-    font-size: 2px;
-    padding: 0.1px;
+  font-size: 2px;
+  padding: 0.1px;
+}
+/* Note mode styling */
+.note-mode-popover {
+  background-color: rgba(154, 205, 50, 0.1); /* Light green background */
+  border: 2px solid rgba(154, 205, 50, 0.3);
+}
+
+.note-mode-header {
+  color: #6b8e23; /* Dark olive green */
+  font-weight: bold;
+}
+
+/* Number mode styling */
+.number-mode-popover {
+  background-color: rgba(70, 130, 180, 0.1); /* Light blue background */
+  border: 2px solid rgba(70, 130, 180, 0.3);
+}
+
+.number-mode-header {
+  color: #4682b4; /* Steel blue */
+  font-weight: bold;
 }


### PR DESCRIPTION
# Make Normal 'Enter Number' Dialogue Distinguishable from 'Add Note' Dialogue

## 🎯 Overview
This PR resolves issue #201 by making the "Enter Number" and "Add Note" dialogues visually distinguishable through clear headers and subtle color coding.

## 📝 Problem Statement
Previously, both dialogues looked identical, making it difficult for users to know whether they were in:
- Normal number entry mode (single tap/click)
- Note addition mode (pencil mode or right-click)

This caused confusion, especially when watching someone else play or when uncertain about the input method used.

## ✨ Solution Implemented

### Visual Improvements
1. **Clear Headers**: Added descriptive headers to each dialogue
   - "Add Number:" for normal input mode
   - "Add Note:" for note/pencil mode

2. **Color Coding**: Implemented subtle background colors
   - 🔵 Light blue theme for "Add Number" mode
   - 🟢 Light green theme for "Add Note" mode

3. **Enhanced Layout**: Restructured the popover with proper spacing and margins

### Technical Changes

#### Modified Files
- **`src/game_manager.py`** (Primary changes)
  - Refactored `_show_popover()` method
  - Added dynamic header generation based on input mode
  - Implemented CSS class assignment for styling
  - Enhanced layout structure with vertical box container

- **`data/style.css`** (New styling - needs to be added)
  - Added CSS classes for visual differentiation
  - Defined color schemes for both modes

## 🔍 Implementation Details

### Header Logic
```python
# Determine mode
ctrl_is_pressed = mouse_button == 3  # Right click
in_note_mode = self.pencil_mode or ctrl_is_pressed

# Dynamic header assignment
if in_note_mode:
    header_label = Gtk.Label(label=_("Add Note:"))
    popover.add_css_class("note-mode-popover")
else:
    header_label = Gtk.Label(label=_("Add Number:"))
    popover.add_css_class("number-mode-popover")